### PR TITLE
docs: fix README directory instruction

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -1,0 +1,4 @@
+# Action Log
+
+- Corrected README setup instructions to use the proper directory name.
+- Added this action log.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Track projects, meeting notes, and tasks without a server — everything stays i
 ### 1. Clone or Download
 ```bash
 git clone https://github.com/bpopineau/essco-tracker.git
-cd SinglePageWebApp
+cd essco-tracker
 ```
 Or download as ZIP from GitHub and unzip.
 


### PR DESCRIPTION
## Summary
- correct README clone instructions to change `cd SinglePageWebApp` to `cd essco-tracker`
- add action log documenting repository changes

## Testing
- `npm test` *(fails: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689fe674ca1c832bbbf84ef25522b727