### PR TITLE
fix: guard structuredClone usage in storage

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -2,3 +2,4 @@
 
 - Corrected README setup instructions to use the proper directory name.
 - Added this action log.
+- Safely guard structuredClone usage in storage module to prevent ReferenceErrors in environments lacking the API.

--- a/src/storage.js
+++ b/src/storage.js
@@ -23,7 +23,9 @@ export const storage = {
       const raw = localStorage.getItem(STORAGE_KEY);
       if (!raw) {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(schema));
-        return structuredClone ? structuredClone(schema) : safeParse(JSON.stringify(schema), schema);
+        return typeof structuredClone === 'function'
+          ? structuredClone(schema)
+          : safeParse(JSON.stringify(schema), schema);
       }
 
       const parsed = safeParse(raw, {});
@@ -43,7 +45,9 @@ export const storage = {
       return stable;
     } catch {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(schema));
-      return structuredClone ? structuredClone(schema) : safeParse(JSON.stringify(schema), schema);
+      return typeof structuredClone === 'function'
+        ? structuredClone(schema)
+        : safeParse(JSON.stringify(schema), schema);
     }
   },
 


### PR DESCRIPTION
## Summary
- avoid ReferenceError when structuredClone is unavailable by checking for the function before calling
- document fix in ACTIONS log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a008d296f4832b879bc156ec075103