### PR TITLE
Configure npm test with basic date utility tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -3,3 +3,4 @@
 - Corrected README setup instructions to use the proper directory name.
 - Added this action log.
 - Safely guard structuredClone usage in storage module to prevent ReferenceErrors in environments lacking the API.
+- Configured npm test setup with Node's test runner and added basic date utility tests.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "essco-tracker",
+  "version": "1.0.0",
+  "description": "A fast, offline-first project tracker for engineering, construction, and consulting teams.   Track projects, meeting notes, and tasks without a server — everything stays in your browser.",
+  "main": "sw.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "module"
+}

--- a/src/utils/date.test.js
+++ b/src/utils/date.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseDate,
+  toISODate,
+  addDays,
+  daysUntil,
+} from './date.js';
+
+test('parseDate handles YYYY-MM-DD strings in local time', () => {
+  const d = parseDate('2024-02-03');
+  assert.equal(d.getFullYear(), 2024);
+  assert.equal(d.getMonth(), 1); // Months are zero-indexed
+  assert.equal(d.getDate(), 3);
+});
+
+test('addDays shifts the date correctly', () => {
+  const d = addDays('2024-02-03', 2);
+  assert.equal(toISODate(d), '2024-02-05');
+});
+
+test('daysUntil returns 0 when dates match', () => {
+  const ref = parseDate('2024-02-03');
+  assert.equal(daysUntil('2024-02-03', ref), 0);
+});


### PR DESCRIPTION
## Summary
- set up npm project with Node test runner
- add date utility tests and .gitignore
- document changes in action log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a009adf1bc832ba5684e2aead82727