### PR TITLE
Guard date utils against invalid inputs

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -28,9 +28,17 @@ export function parseDate(input) {
   return null;
 }
 
-/** Start-of-day (local) */
+/** Start-of-day (local)
+ *
+ * Previously this function would fall back to `new Date()` when given an
+ * invalid input.  Downstream helpers like `daysUntil` rely on receiving an
+ * invalid `Date` (i.e. `NaN`) so that they can propagate the error via
+ * `isNaN`.  Returning today's date for invalid inputs caused values like
+ * `daysUntil('invalid')` to incorrectly return `0` instead of `NaN`.
+ */
 export function startOfDay(input = new Date()) {
-  const d = parseDate(input) ?? new Date();
+  const d = parseDate(input);
+  if (!d) return new Date(NaN);
   return new Date(d.getFullYear(), d.getMonth(), d.getDate());
 }
 

--- a/src/utils/date.test.js
+++ b/src/utils/date.test.js
@@ -23,3 +23,7 @@ test('daysUntil returns 0 when dates match', () => {
   const ref = parseDate('2024-02-03');
   assert.equal(daysUntil('2024-02-03', ref), 0);
 });
+
+test('daysUntil returns NaN for invalid dates', () => {
+  assert.ok(Number.isNaN(daysUntil('not-a-date')));
+});


### PR DESCRIPTION
## Summary
- Fix `startOfDay` to return an invalid Date for unparseable input so helpers propagate NaN
- Add regression test for `daysUntil` handling of invalid dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a00af4d62c832bb426239ba8dd4488