### PR TITLE
refactor: rename dev flag

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -1,6 +1,6 @@
 # Action Plan (from "works ok" → "rock solid")
 
-Replace any DEV_MODE usage with DEV.
+Replaced outdated dev flag with `DEV`. ✅
 
 - Add lint + type checking (JS projects still).
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,9 +12,9 @@ import { mountNotes } from './views/notes.js';
 import { mountSidebar } from './views/sidebar.js';
 import { mountTasks } from './views/tasks.js';
 
-// ---------- Dev_Mode ----------
-const DEV_MODE = true; // set to false in production
-const schema = buildSchema(DEV_MODE);
+// ---------- Dev ----------
+const DEV = true; // set to false in production
+const schema = buildSchema(DEV);
 
 // ---------- Boot ----------
 (async function main () {
@@ -57,7 +57,7 @@ const schema = buildSchema(DEV_MODE);
   }, store);
 
   // Dev-only Reset Seed button
-  if (DEV_MODE) {
+  if (DEV) {
     const actionsRow = document.querySelector('header .row');
     if (actionsRow) {
       const resetBtn = document.createElement('button');
@@ -173,7 +173,7 @@ const schema = buildSchema(DEV_MODE);
       location.reload();
     });
 
-    console.log('ESSCO build', BUILD_VERSION, 'DEV_MODE:', DEV_MODE ? 'dev' : 'prod');
+    console.log('ESSCO build', BUILD_VERSION, 'DEV:', DEV ? 'dev' : 'prod');
   }
 })();
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,6 +1,6 @@
 export const SCHEMA_VERSION = 3;
 
-export function buildSchema(DEV_MODE) {
+export function buildSchema(DEV) {
   const VERSION = SCHEMA_VERSION;
 
   const emptyUI = {
@@ -24,7 +24,7 @@ export function buildSchema(DEV_MODE) {
     ui: emptyUI
   };
 
-  if (!DEV_MODE) return empty;
+  if (!DEV) return empty;
 
   const sample = {
     ...empty,


### PR DESCRIPTION
## Summary
- replace outdated DEV_MODE flag with DEV constant
- note completion in action plan

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0137ffaf4832b94569fd71f4f5e0d