### PR TITLE
perf: preload main module

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -53,7 +53,7 @@ navigator.serviceWorker.register('/sw.js?v=' + BUILD_VERSION).then(reg => {
 function promptReload(worker){ showToast('Update available', 'Reload', () => worker.postMessage({type:'SKIP_WAITING'})); }
 ```
 
-- Preload entry modules in index.html:
+- Preload entry modules in index.html: ✅
 
 ```
 <link rel="modulepreload" href="./src/main.js">

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16.png">
 
   <link rel="stylesheet" href="./styles.css">
+  <link rel="modulepreload" href="./src/main.js">
 </head>
 <body>
 <noscript>


### PR DESCRIPTION
## Summary
- preload main module in index.html for faster startup
- update action plan to mark module preload done

## Testing
- `npm test`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a014c34718832b921da8494fd42d42